### PR TITLE
Add solver for MILP/MIQP, minor change

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ python3 minlp_algorithms run fp+s-b-miqp <problem>
 
 ```
 
+#### Issues with CasADi function eval
+Some examples we provided make use of CasADi subroutines (e.g., `bspline`) which only accept `casadi MX` symbolics.\
+If you experience the following error (or similar)
+```
+.../casadi/core/function_internal.cpp:2013: 'eval_sx' not defined for BSplineInterpolant
+```
+Please goto `settings.py` and update the default value for `_CASADI_VAR` to `ca.MX`.
+
+
 ### Install pycombina
 
 - Install gcc

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ You can enable or change options using environmental variables:
 | cia | Combinatorial Integral Approximation ([Sager, et al, 2011](https://link.springer.com/article/10.1007/s00186-011-0355-4)) using `pycombina` ([Buerger, et al, 2020](https://publications.syscop.de/Buerger2020a.pdf)) -- installation instructions below|  |  |
 | nlp | Solve the canonical relaxation of the MINLP (integers are relaxed to continuous variables) |  |  |
 | nlp-fxd | Fix the integer variables of the MINLP and solve the corresponding NLP|  |  |
+| mip | Solve the given MILP/MIQP |  | (x) |
 
 #### Warm starting
 It is possible to warm start every solver with the solution of another one by concatenating with a `+` the desired solvers when executing `python3 minlp_algorithms`.

--- a/minlp_algorithms/settings.py
+++ b/minlp_algorithms/settings.py
@@ -19,7 +19,7 @@ def create_and_return(folder):
 @dataclass
 class _GlobalSettings:
     _lock: bool = False
-    _CASADI_VAR: Any = ca.MX
+    _CASADI_VAR: Any = ca.SX
     SOURCE_FOLDER: str = path.dirname(path.abspath(__file__))
     _DATA_FOLDER: str = path.join(SOURCE_FOLDER, "../data")
     _IMG_DIR: str = path.join(SOURCE_FOLDER, "../results/figures")

--- a/minlp_algorithms/settings.py
+++ b/minlp_algorithms/settings.py
@@ -66,6 +66,15 @@ class _GlobalSettings:
         """Set output dir directory."""
         self._CACHE_FOLDER = value
 
+    @property
+    def DATA_FOLDER(self):
+        return create_and_return(self._DATA_FOLDER)
+
+    @DATA_FOLDER.setter
+    def DATA_FOLDER(self, value):
+        """Set output dir directory."""
+        self._DATA_FOLDER = value
+
 
 GlobalSettings = _GlobalSettings()
 

--- a/minlp_algorithms/solver.py
+++ b/minlp_algorithms/solver.py
@@ -15,6 +15,7 @@ from minlp_algorithms.solvers.external.bonmin import BonminSolver
 from minlp_algorithms.solvers.pumps import FeasibilityPump, ObjectiveFeasibilityPump, RandomObjectiveFeasibilityPump
 from minlp_algorithms.solvers.approximation import CiaSolver
 from minlp_algorithms.solvers.relaxation import NlpSolver
+from minlp_algorithms.solvers.mip import MipSolver
 
 SOLVER_MODES = {
     "gbd": GeneralizedBenders,
@@ -38,6 +39,7 @@ SOLVER_MODES = {
     "cia": CiaSolver,
     "nlp": lambda *args, **kwargs: NlpSolver(*args, **kwargs, set_bin=False),
     "nlp-fxd": lambda *args, **kwargs: NlpSolver(*args, **kwargs, set_bin=True),
+    "mip": MipSolver,
 }
 
 

--- a/minlp_algorithms/solvers/mip/__init__.py
+++ b/minlp_algorithms/solvers/mip/__init__.py
@@ -1,0 +1,60 @@
+# This file is part of minlp-algorithms
+# Copyright (C) 2024  Andrea Ghezzi, Wim Van Roy, Sebastian Sager, Moritz Diehl
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""A MIP solver."""
+
+import casadi as ca
+import logging
+from minlp_algorithms.solvers import MiSolverClass, Stats, MinlpProblem, MinlpData, \
+    regularize_options
+from minlp_algorithms.settings import Settings
+
+logger = logging.getLogger(__name__)
+
+
+class MipSolver(MiSolverClass):
+    """
+    Create MIP solver.
+
+    This solver solves a mixed-integer problem (MIP).
+    Constraints must be linear, for linear objective it solves a MILP, for quadratic
+    cost it solves a MIQP.
+    """
+
+    def __init__(self, problem: MinlpProblem, data: MinlpData, stats: Stats, s: Settings):
+        """Create NLP problem."""
+        super(MipSolver, self).__init__(problem, data, stats, s)
+        self.options = regularize_options(s.MIP_SETTINGS, {}, s)
+
+        self.idx_x_bin = problem.idx_x_bin
+        self.nr_x = problem.x.shape[0]
+
+        self.options["discrete"] = [
+            1 if i in self.idx_x_bin else 0 for i in range(self.nr_x)]
+
+        self.solver = ca.qpsol(
+            "mip_solver", self.settings.MIP_SOLVER, {
+                "f": problem.f, "g": problem.g, "x": problem.x, "p": problem.p,
+            }, self.options)
+
+    def solve(self, nlpdata: MinlpData) -> MinlpData:
+        """Solve given MIP."""
+
+        nlpdata.prev_solution = self.solver(
+            x0=nlpdata.x0, lbx=nlpdata.lbx, ubx=nlpdata.ubx,
+            lbg=nlpdata.lbg, ubg=nlpdata.ubg, p=nlpdata.p)
+
+        nlpdata.solved, stats = self.collect_stats(
+            "MIP", sol=nlpdata.prev_solutions[-1])
+        return nlpdata
+
+    def reset(self, nlpdata: MinlpData):
+        """Reset problem data."""
+        logger.warning(
+            "reset method not available for MipSolver class!")
+
+    def warmstart(self, nlpdata: MinlpData):
+        """Warmstart the algorithm."""
+        logger.warning(
+            "warmstart method not available for MipSolver class. To pass a linearization point use 'nlpdata.x0'.")


### PR DESCRIPTION
- add solver for MILP/MIQP
- fix bug on `DATA_FOLDER`
- set `ca.SX` as default `CASADI_VAR` since it is used more often. Add on `README` a notification section on possible error with casadi subroutines like `bspline`